### PR TITLE
カバレッジはかろー

### DIFF
--- a/Application/MatchGeneratorTest/packages.config
+++ b/Application/MatchGeneratorTest/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.2" targetFramework="net461" />
+  <package id="coveralls.net" version="0.7.0" targetFramework="net461" developmentDependency="true" />
   <package id="OpenCover" version="4.6.519" targetFramework="net461" />
   <package id="Prism" version="5.0.0" targetFramework="net461" />
   <package id="Prism.Composition" version="5.0.0" targetFramework="net461" />

--- a/Application/MatchGeneratorTest/packages.config
+++ b/Application/MatchGeneratorTest/packages.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.2" targetFramework="net461" />
+  <package id="OpenCover" version="4.6.519" targetFramework="net461" />
   <package id="Prism" version="5.0.0" targetFramework="net461" />
   <package id="Prism.Composition" version="5.0.0" targetFramework="net461" />
   <package id="Prism.Interactivity" version="5.0.0" targetFramework="net461" />

--- a/Application/MatchGeneratorTest/packages.config
+++ b/Application/MatchGeneratorTest/packages.config
@@ -14,5 +14,6 @@
   <package id="xunit.core" version="2.1.0" targetFramework="net461" />
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net461" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.1.0" targetFramework="net461" />
   <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Issue : #28
## リポジトリ以外の変更

AppVayorの設定

本来はこれをappvayor.ymlとしてリポジトリ直下に置く.

``` yaml
version: 0.0.{build}
environment:
  COVERALLS_REPO_TOKEN:
    secure: CNxmSZIK1YP+NIigJLIP2WjLgbGdYp5SDTYzgAfRWqHEYUcgoOapURoyzH80+G2F
before_build:
- cmd: nuget restore Application\MatchGenerator.sln
build:
  project: Application/MatchGenerator.sln
  verbosity: minimal
test:
  assemblies: Application\MatchGeneratorTest\bin\Debug\MatchGeneratorTest.dll
after_test:
- cmd: >-
    Application\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:Application\packages\xunit.runner.console.2.1.0\tools\xunit.console.exe -targetargs:"Application\MatchGeneratorTest\bin\Debug\MatchGeneratorTest.dll -noshadow" -filter:"+[MatchGenerator]* +[MatchGenerator.*]*" -output:coverage.xml
    Application\packages\coveralls.net.0.7.0\tools\csmacnz.Coveralls.exe --opencover -i coverage.xml
artifacts:
- path: Application\MatchGenerator\bin\Debug\MatchGenerator.exe
  name: MatchGenerator
```
## 結果

これを見るがよい! [Coveralls](https://coveralls.io/builds/8144813)
