### PR TITLE
MemberListViewModel.Members が返す値は, 普通のIListとする

### DIFF
--- a/Application/MatchGenerator/ViewModel/MemberListViewModel.cs
+++ b/Application/MatchGenerator/ViewModel/MemberListViewModel.cs
@@ -47,7 +47,6 @@ namespace MatchGenerator.ViewModel
 			set
 			{
 				SetProperty(ref MembersField, new ObservableCollection<IMemberListItemViewModel>(value));
-				MembersField.CollectionChanged += CollectionChanged;
 				OnPropertyChanged(nameof(SelectedMembers));
 			}
 		}

--- a/Application/MatchGenerator/ViewModel/MemberListViewModel.cs
+++ b/Application/MatchGenerator/ViewModel/MemberListViewModel.cs
@@ -31,7 +31,7 @@ namespace MatchGenerator.ViewModel
 			}
 		}
 
-		private ObservableCollection<IMemberListItemViewModel> MembersField;
+		private IList<IMemberListItemViewModel> MembersField;
 		/// <summary>
 		/// リストに表示するすべてのメンバー
 		/// </summary>
@@ -46,7 +46,7 @@ namespace MatchGenerator.ViewModel
 
 			set
 			{
-				SetProperty(ref MembersField, new ObservableCollection<IMemberListItemViewModel>(value));
+				SetProperty(ref MembersField, value);
 				OnPropertyChanged(nameof(SelectedMembers));
 			}
 		}

--- a/Application/MatchGeneratorTest/ViewModel/MemberListViewModelTest.cs
+++ b/Application/MatchGeneratorTest/ViewModel/MemberListViewModelTest.cs
@@ -154,38 +154,6 @@ namespace MatchGeneratorTest.ViewModel
 			Assert.True(actualPropertyChangedParamsE.Select(e => e.PropertyName).SequenceEqual(expectedPropertyChangedParamsE));
 		}
 
-		[Fact(DisplayName = nameof(MemberListViewModel.Members) + ".Setterプロパティ : 正常系 : コレクション変更イベントが設定されること")]
-		[Trait("category", "ViewModel"), Trait("type", "正常系")]
-		public void MemberSetTest_CollectionChangedEvent()
-		{
-			// Arrange
-			IList<IMemberListItemViewModel> inputMembers = new List<IMemberListItemViewModel>();
-			IMemberListItemViewModel addedMember = new Mock<IMemberListItemViewModel>().Object;
-			// Event handler
-			IList<object> actualSenderParamsOfCollectionChanged = new List<object>();
-			IList<NotifyCollectionChangedEventArgs> actualEParamsOfCollectionChanged = new List<NotifyCollectionChangedEventArgs>();
-			Instance.CollectionChanged += (s, e) =>
-			{
-				actualSenderParamsOfCollectionChanged.Add(s);
-				actualEParamsOfCollectionChanged.Add(e);
-			};
-			// Expected data
-			IList<object> expectedSenderParamsOfCollectionChanged = new List<object>();
-			IList<IMemberListItemViewModel> expectedNewItemsOfEParamOfCollectionChanged = new List<IMemberListItemViewModel> { addedMember };
-
-			// Act
-			Instance.Members = inputMembers;
-			ObservableCollection<IMemberListItemViewModel> membersField =
-				(ObservableCollection<IMemberListItemViewModel>)Instance.GetPrivateField(MemberListViewModelMember.MembersField);
-			membersField.Add(addedMember);
-
-			// Assert
-			expectedSenderParamsOfCollectionChanged.Add(membersField);
-			Assert.Equal(expectedSenderParamsOfCollectionChanged, actualSenderParamsOfCollectionChanged);
-			Assert.Equal(expectedNewItemsOfEParamOfCollectionChanged, 
-				actualEParamsOfCollectionChanged.Select(e => e.NewItems[0]).Cast<IMemberListItemViewModel>().ToList());
-		}
-
 		[Fact(DisplayName = nameof(MemberListViewModel.SelectedMembers) + ".Getterプロパティ : 正常系")]
 		[Trait("category", "ViewModel")]
 		[Trait("type", "正常系")]

--- a/Application/MatchGeneratorTest/ViewModel/MemberListViewModelTest.cs
+++ b/Application/MatchGeneratorTest/ViewModel/MemberListViewModelTest.cs
@@ -127,8 +127,7 @@ namespace MatchGeneratorTest.ViewModel
 		public void MembersSetTest()
 		{
 			// Arrange
-			IList<IMemberListItemViewModel> inputMembers =
-				new ObservableCollection<IMemberListItemViewModel>(MembersFieldMocks.Select(mock => mock.Object));
+			IList<IMemberListItemViewModel> inputMembers = MembersFieldMocks.Select(mock => mock.Object).ToList();
 			IList<IMemberListItemViewModel> expectedMembersField = inputMembers;
 			// Event handler
 			IList<object> actualPropertyChangedParamsSender = new List<object>();
@@ -146,8 +145,7 @@ namespace MatchGeneratorTest.ViewModel
 			Instance.Members = inputMembers;
 
 			// Assert
-			ObservableCollection<IMemberListItemViewModel> actualMembersField =
-				(ObservableCollection<IMemberListItemViewModel>)Instance.GetPrivateField(MemberListViewModelMember.MembersField);
+			var actualMembersField = (IList<IMemberListItemViewModel>)Instance.GetPrivateField(MemberListViewModelMember.MembersField);
 			Assert.Equal(expectedMembersField, actualMembersField);
 			// Called handler
 			Assert.True(actualPropertyChangedParamsSender.SequenceEqual(expectedPropertyChangedParamsSender));


### PR DESCRIPTION
Issue : #96

普通の `IList` にした.
